### PR TITLE
fix: add missing AnalyticsApp import in GoogleAnalyticsResource

### DIFF
--- a/src/main/java/com/dotcms/google/analytics/rest/GoogleAnalyticsResource.java
+++ b/src/main/java/com/dotcms/google/analytics/rest/GoogleAnalyticsResource.java
@@ -1,5 +1,6 @@
 package com.dotcms.google.analytics.rest;
 
+import com.dotcms.google.analytics.app.AnalyticsApp;
 import com.dotcms.google.analytics.app.AnalyticsAppService;
 import com.dotcms.google.analytics.model.AnalyticsRequest;
 import com.dotcms.google.analytics.model.FilterRequest;


### PR DESCRIPTION
## Summary
- Adds missing `import com.dotcms.google.analytics.app.AnalyticsApp` to `GoogleAnalyticsResource.java`
- This import was required but omitted, causing a compilation error in CI

## Test plan
- [ ] Run `./gradlew clean jar` and verify the build succeeds with no compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)